### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, dev]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/re0wiki/wiki-bot/security/code-scanning/1](https://github.com/re0wiki/wiki-bot/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so token scopes are documented and restricted regardless of repository/org defaults.

Best fix here (without changing behavior): add workflow-level permissions with `contents: read` (the minimal recommended scope for checkout and read-only CI). This applies to all jobs unless overridden and is appropriate for the single `check` job shown.

Change location: `.github/workflows/ci.yml`, directly under `on:` block (or under `name:`/before `jobs:`), add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
